### PR TITLE
Automatically backup terraforming_atmosphere.xml

### DIFF
--- a/TerraformingMod/Terraforming.cs
+++ b/TerraformingMod/Terraforming.cs
@@ -143,10 +143,11 @@ namespace TerraformingMod
             // load saved atmosphere
             if (XmlSaveLoad.Instance.CurrentWorldSave != null)
             {
-                var fileName = StationSaveUtils.GetWorldSaveDirectory(XmlSaveLoad.Instance.CurrentWorldSave.Name) + "/" + TerraformingFunctions.TerraformingFilename;
+                var fileName = XmlSaveLoad.Instance.CurrentWorldSave.World.Directory.FullName + "/" + TerraformingFunctions.TerraformingFilenameBuilder(XmlSaveLoad.Instance.CurrentWorldSave);
+                ConsoleWindow.Print("Terraforming: Loading from: " + fileName, ConsoleColor.Yellow);
                 object obj = XmlSerialization.Deserialize(TerraformingFunctions.AtmoSerializer, fileName);
                 if (!(obj is TerraformingAtmosphere terraformingAtmosphere))
-                {
+                {   
                     ConsoleWindow.Print("Terraforming: Failed to load the terraforming_atmosphere.xml: " + fileName, ConsoleColor.Red);
                 }
                 else
@@ -379,7 +380,19 @@ namespace TerraformingMod
 
         public static GlobalAtmospherePrecise ThisGlobalPrecise;
         private static Atmosphere _global = null;
+        
         public const string TerraformingFilename = "terraforming_atmosphere.xml";
+        public static string TerraformingFilenameBuilder(StationSaveContainer save) 
+        {
+            if (save.IsBackup)
+            {
+                return "terraforming_atmosphere(" + save.Index.ToString() + ").xml";
+            }
+            else
+            {
+                return "terraforming_atmosphere.xml";
+            }
+        } 
 
         [ThreadStatic]
         public static bool JoinInProgress = false;

--- a/TerraformingMod/Terraforming.cs
+++ b/TerraformingMod/Terraforming.cs
@@ -15,6 +15,7 @@ using Assets.Scripts.Serialization;
 using static Assets.Scripts.Atmospherics.Chemistry;
 using TerraformingMod.Tools;
 using System.Reflection;
+using Assets.Scripts.UI;
 
 namespace TerraformingMod
 {
@@ -340,6 +341,22 @@ namespace TerraformingMod
                 }
                 ConsoleWindow.Print("Exported Terraforming Atmosphere");
             }
+        }
+    }
+
+    [HarmonyPatch(typeof(XmlSaveLoad), "BackupWorldFiles")]
+    public class WorldManagerBackupWorldSettingDataPatch
+    {
+        [HarmonyPrefix]
+        public static void Prefix(string worldDirectory, bool autoSave, XmlSaveLoad __instance)
+        {
+            //__instance.BackupEachFiles(worldDirectory, TerraformingFunctions.TerraformingFilename, autoSave);
+            var BackupEachFiles = __instance.GetType().GetMethod("BackupEachFiles", BindingFlags.NonPublic | BindingFlags.Instance);
+            BackupEachFiles.Invoke(__instance, new object[] {worldDirectory, TerraformingFunctions.TerraformingFilename, autoSave});
+            
+            //XmlSaveLoad.DeleteEachFilesOldAutoSaves(worldDirectory, XmlSaveLoad.WorldFileName);
+            var DeleteEachFilesOldAutoSaves = __instance.GetType().GetMethod("DeleteEachFilesOldAutoSaves", BindingFlags.NonPublic | BindingFlags.Instance);
+            BackupEachFiles.Invoke(__instance, new object[] {worldDirectory, TerraformingFunctions.TerraformingFilename, autoSave});
         }
     }
 

--- a/TerraformingMod/Terraforming.cs
+++ b/TerraformingMod/Terraforming.cs
@@ -15,7 +15,6 @@ using Assets.Scripts.Serialization;
 using static Assets.Scripts.Atmospherics.Chemistry;
 using TerraformingMod.Tools;
 using System.Reflection;
-using Assets.Scripts.UI;
 
 namespace TerraformingMod
 {


### PR DESCRIPTION
Patches XmlSaveLoad.BackupWorldFiles to also backup terraforming_atmosphere.xml. This allows rolling back world atmosphere when loading a save. Previously bad accidents or griefers could irreparably damage world atmosphere (especially problematic with volatiles).